### PR TITLE
Honor consul.url and consul.addr from config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,9 @@ func main() {
 		log.Fatal("[FATAL] ", err)
 	}
 
+	consul.Addr = consulAddr;
+	consul.URL = consulURL;
+
 	dc, err := consul.Datacenter()
 	if err != nil {
 		log.Fatal("[FATAL] ", err)


### PR DESCRIPTION
Looks like values for consul.addr and consul.url from the config file aren't passed to the consul client - fabio still tries to connect to localhost, so here's a quick fix.
Maybe these should rather be passed as arguments to NewWatcher (sorry, don't know much about go).
