### PR TITLE
fix vet warning

### DIFF
--- a/consul/watch_auto_config.go
+++ b/consul/watch_auto_config.go
@@ -66,7 +66,7 @@ func serviceConfig(client *api.Client, name string, passing map[string]bool, tag
 	q := &api.QueryOptions{RequireConsistent: true}
 	svcs, _, err := client.Catalog().Service(name, "", q)
 	if err != nil {
-		log.Printf("[WARN] [%s] Error getting catalog service %s. %v", name, err)
+		log.Printf("[WARN] Error getting catalog service %s. %v", name, err)
 		return nil
 	}
 


### PR DESCRIPTION
Just to avoid this warning when vetting:
go vet ./...
consul/watch_auto_config.go:69: missing argument for Printf("%v"): format reads arg 3, have only 2 args
exit status 1