### PR TITLE
[registry] fallback to given local IP address

### DIFF
--- a/registry/consul/register.go
+++ b/registry/consul/register.go
@@ -17,7 +17,7 @@ func serviceRegistration(addr, name string, interval, timeout time.Duration) (*a
 	if err != nil {
 		return nil, err
 	}
-	_, portstr, err := net.SplitHostPort(addr)
+	ipstr, portstr, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +31,11 @@ func serviceRegistration(addr, name string, interval, timeout time.Duration) (*a
 		return nil, err
 	}
 	if ip == nil {
-		return nil, errors.New("no local ip")
+		givenip := net.ParseIP(ipstr)
+                if givenip == nil {
+                        return nil, errors.New("no local ip")
+                }
+                ip = givenip
 	}
 
 	serviceID := fmt.Sprintf("%s-%s-%d", name, hostname, port)


### PR DESCRIPTION
Fabio has configuration for every IP binding, but relies on autodetection for registration with Consul.  I propose falling back to the IP given in the config.

I ran into this issue on SmartOS, where Go did not detect a local IP from my 3 VLANs.  You may already be changing the address config (#28), please consider this in the new version.

Fabio runs great otherwise on SmartOS.  Thanks for your work!