### PR TITLE
Fix use of local ip in consul service registration

### DIFF
--- a/registry/consul/backend.go
+++ b/registry/consul/backend.go
@@ -45,7 +45,7 @@ func (b *be) Register() error {
 		return err
 	}
 
-	log.Printf("[INFO] consul: Registered fabio as %q with address %q", service.ID, b.cfg.ServiceAddr)
+	log.Printf("[INFO] consul: Registered fabio as %q with address %q and health check to %q", service.ID, b.cfg.ServiceAddr, service.Check.HTTP)
 	b.serviceID = service.ID
 	return nil
 }

--- a/registry/consul/register.go
+++ b/registry/consul/register.go
@@ -28,7 +28,7 @@ func serviceRegistration(addr, name string, interval, timeout time.Duration) (*a
 
 	ip := net.ParseIP(ipstr)
 	if ip == nil {
-		ip, err := config.LocalIP()
+		ip, err = config.LocalIP()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When using the default registry.consul.register.ip, the service and health check ip were set to "<nil>",
making the health check fail.

This was regressed by PR #49, due to golang variable initialization magic.