### PR TITLE
proxy header handling

### DIFF
--- a/fabio.properties
+++ b/fabio.properties
@@ -35,7 +35,7 @@
 
 
 # proxy.localip configures the ip address of the proxy which is added
-# to the X-Forwarded-For and Forwarded headers.
+# to the Forwarded header.
 #
 # The local non-loopback address is detected during startup
 # but can be overwritten with this property.
@@ -102,19 +102,6 @@
 # proxy.header.clientip configures the header for the request ip.
 #
 # The remoteIP is taken from http.Request.RemoteAddr.
-# The localIP is either detected or the value of proxy.localip.
-#
-# When set to 'X-Forwarded-For' the proxy will set this header to
-#
-#   <remoteIP>, <localIP>
-#
-# if the header is not set in the incoming request. Otherwise, it
-# will just append
-#
-#   , <localIP>
-#
-# to the existing header value.
-#
 # When set to another non-empty value the proxy will set this header
 # to
 #

--- a/proxy/http_test.go
+++ b/proxy/http_test.go
@@ -1,0 +1,36 @@
+package proxy
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// Test, that the proxy calls the target
+// with the target host as host header,
+// and not with the ip of the request to the proxy itself
+func TestCorrectHostHeader(t *testing.T) {
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.Host))
+	}))
+
+	defer server.Close()
+	serverUrl, _ := url.Parse(server.URL)
+
+	tr := &http.Transport{
+		Dial: (&net.Dialer{}).Dial,
+	}
+	proxy := newHTTPProxy(serverUrl, tr)
+
+	req, _ := http.NewRequest("GET", "http://example.com:666", nil)
+	res := httptest.NewRecorder()
+
+	proxy.ServeHTTP(res, req)
+
+	if serverUrl.Host != res.Body.String() {
+		t.Errorf("expected host was %v, but got %v", serverUrl.Host, res.Body.String())
+	}
+}

--- a/proxy/util_test.go
+++ b/proxy/util_test.go
@@ -7,118 +7,143 @@ import (
 	"testing"
 
 	"github.com/eBay/fabio/config"
+	"net"
 )
 
-func TestAddHeaders(t *testing.T) {
-	tests := []struct {
-		r    *http.Request
-		cfg  config.Proxy
-		hdrs http.Header
-		err  string
-	}{
-		{ // error
-			&http.Request{RemoteAddr: "1.2.3.4"},
-			config.Proxy{},
-			http.Header{},
-			"cannot parse 1.2.3.4",
-		},
+type headerTestset []struct {
+	desc string
+	r    *http.Request
+	cfg  config.Proxy
+	hdrs http.Header
+}
 
-		{ // set remote ip header
-			&http.Request{RemoteAddr: "1.2.3.4:5555"},
-			config.Proxy{ClientIPHeader: "Client-IP"},
-			http.Header{"Forwarded": {"for=1.2.3.4; proto=http"}, "Client-Ip": []string{"1.2.3.4"}},
-			"",
-		},
+func Test_addHeaders_ParsingEror(t *testing.T) {
+	want := "cannot parse 1.2.3.4"
+	got := addHeaders(
+		&http.Request{RemoteAddr: "1.2.3.4"},
+		config.Proxy{LocalIP: "5.6.7.8"},
+	)
+	if got.Error() != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
 
-		{ // set remote ip header with local ip (no change expected)
-			&http.Request{RemoteAddr: "1.2.3.4:5555"},
-			config.Proxy{LocalIP: "5.6.7.8", ClientIPHeader: "Client-IP"},
-			http.Header{"Forwarded": {"for=1.2.3.4; proto=http; by=5.6.7.8"}, "Client-Ip": []string{"1.2.3.4"}},
-			"",
-		},
+func Test_addHeaders_AllTogether(t *testing.T) {
+	request := &http.Request{RemoteAddr: "1.2.3.4:5555", Host: "example.com:8080", TLS: &tls.ConnectionState{}, Header: http.Header{}}
+	addHeaders(
+		request,
+		config.Proxy{LocalIP: "5.6.7.8", ClientIPHeader: "Client-IP", TLSHeader: "Secure", TLSHeaderValue: "true"},
+	)
 
-		{ // set X-Forwarded-For
-			&http.Request{RemoteAddr: "1.2.3.4:5555"},
-			config.Proxy{ClientIPHeader: "X-Forwarded-For"},
-			http.Header{"Forwarded": {"for=1.2.3.4; proto=http"}, "X-Forwarded-For": []string{"1.2.3.4"}},
-			"",
-		},
-
-		{ // set X-Forwarded-For with local ip
-			&http.Request{RemoteAddr: "1.2.3.4:5555"},
-			config.Proxy{LocalIP: "5.6.7.8", ClientIPHeader: "X-Forwarded-For"},
-			http.Header{"Forwarded": {"for=1.2.3.4; proto=http; by=5.6.7.8"}, "X-Forwarded-For": []string{"1.2.3.4, 5.6.7.8"}},
-			"",
-		},
-
-		{ // extend X-Forwarded-For with local ip
-			&http.Request{RemoteAddr: "1.2.3.4:5555", Header: http.Header{"X-Forwarded-For": []string{"9.9.9.9"}}},
-			config.Proxy{LocalIP: "5.6.7.8"},
-			http.Header{"Forwarded": {"for=1.2.3.4; proto=http; by=5.6.7.8"}, "X-Forwarded-For": []string{"9.9.9.9, 5.6.7.8"}},
-			"",
-		},
-
-		{ // set Forwarded
-			&http.Request{RemoteAddr: "1.2.3.4:5555"},
-			config.Proxy{},
-			http.Header{"Forwarded": {"for=1.2.3.4; proto=http"}},
-			"",
-		},
-
-		{ // set Forwarded with localIP
-			&http.Request{RemoteAddr: "1.2.3.4:5555"},
-			config.Proxy{LocalIP: "5.6.7.8"},
-			http.Header{"Forwarded": {"for=1.2.3.4; proto=http; by=5.6.7.8"}},
-			"",
-		},
-
-		{ // set Forwarded with localIP and HTTPS
-			&http.Request{RemoteAddr: "1.2.3.4:5555", TLS: &tls.ConnectionState{}},
-			config.Proxy{LocalIP: "5.6.7.8"},
-			http.Header{"Forwarded": {"for=1.2.3.4; proto=https; by=5.6.7.8"}},
-			"",
-		},
-
-		{ // extend Forwarded with localIP
-			&http.Request{RemoteAddr: "1.2.3.4:5555", Header: http.Header{"Forwarded": {"for=9.9.9.9; proto=http; by=8.8.8.8"}}},
-			config.Proxy{LocalIP: "5.6.7.8"},
-			http.Header{"Forwarded": {"for=9.9.9.9; proto=http; by=8.8.8.8; by=5.6.7.8"}},
-			"",
-		},
-
-		{ // set tls header
-			&http.Request{RemoteAddr: "1.2.3.4:5555", TLS: &tls.ConnectionState{}},
-			config.Proxy{LocalIP: "5.6.7.8", TLSHeader: "Secure"},
-			http.Header{"Forwarded": {"for=1.2.3.4; proto=https; by=5.6.7.8"}, "Secure": {""}},
-			"",
-		},
-
-		{ // set tls header with value
-			&http.Request{RemoteAddr: "1.2.3.4:5555", TLS: &tls.ConnectionState{}},
-			config.Proxy{LocalIP: "5.6.7.8", TLSHeader: "Secure", TLSHeaderValue: "true"},
-			http.Header{"Forwarded": {"for=1.2.3.4; proto=https; by=5.6.7.8"}, "Secure": {"true"}},
-			"",
-		},
+	expected := http.Header{
+		"Client-Ip":         {"1.2.3.4"},
+		"X-Real-Ip":         {"1.2.3.4"},
+		"X-Forwarded-Host":  {"example.com:8080"},
+		"X-Forwarded-Proto": {"https"},
+		"Forwarded":         {"for=1.2.3.4; proto=https; by=5.6.7.8; host=example.com:8080"},
+		"Secure":            {"true"},
 	}
 
+	if !reflect.DeepEqual(request.Header, expected) {
+		t.Errorf("Headers don't match: \ngot  %v\nwant %v", request.Header, expected)
+	}
+}
+
+func Test_addRemoteIpHeaders(t *testing.T) {
+	executeHeaderTests(t, addRemoteIpHeaders,
+		headerTestset{
+			{"set remote ip header",
+				&http.Request{RemoteAddr: "1.2.3.4:5555"},
+				config.Proxy{ClientIPHeader: "Client-IP"},
+				http.Header{"Client-Ip": {"1.2.3.4"}, "X-Real-Ip": {"1.2.3.4"}},
+			},
+
+			{"X-Forwarded-For is skipped as client ip header, because it will be set by golang proxy, later",
+				&http.Request{RemoteAddr: "1.2.3.4:5555"},
+				config.Proxy{ClientIPHeader: "X-Forwarded-For"},
+				http.Header{"X-Real-Ip": {"1.2.3.4"}},
+			},
+
+			{"set remote ip header with local ip (no change expected)",
+				&http.Request{RemoteAddr: "1.2.3.4:5555"},
+				config.Proxy{LocalIP: "5.6.7.8", ClientIPHeader: "Client-IP"},
+				http.Header{"Client-Ip": {"1.2.3.4"}, "X-Real-Ip": {"1.2.3.4"}},
+			},
+		})
+}
+
+func Test_addXForwardedHeaders(t *testing.T) {
+	executeHeaderTests(t, addXForwardedHeaders,
+		headerTestset{
+			{"set X-Forwarded Host and Proto",
+				&http.Request{RemoteAddr: "1.2.3.4:5555", Host: "example.com:8080"},
+				config.Proxy{},
+				http.Header{"X-Forwarded-Host": {"example.com:8080"}, "X-Forwarded-Proto": {"http"}},
+			},
+			{"set X-Forwarded Host and Proto with TLS",
+				&http.Request{RemoteAddr: "1.2.3.4:5555", Host: "example.com:8080", TLS: &tls.ConnectionState{}},
+				config.Proxy{},
+				http.Header{"X-Forwarded-Host": {"example.com:8080"}, "X-Forwarded-Proto": {"https"}},
+			},
+		})
+}
+
+func Test_addForwardedHeader(t *testing.T) {
+	executeHeaderTests(t, addForwardedHeader,
+		headerTestset{
+			{"set Forwarded",
+				&http.Request{RemoteAddr: "1.2.3.4:5555", Host: "example.com:8080"},
+				config.Proxy{},
+				http.Header{"Forwarded": {"for=1.2.3.4; proto=http; host=example.com:8080"}},
+			},
+
+			{"set Forwarded with localIP",
+				&http.Request{RemoteAddr: "1.2.3.4:5555", Host: "example.com:8080"},
+				config.Proxy{LocalIP: "5.6.7.8"},
+				http.Header{"Forwarded": {"for=1.2.3.4; proto=http; by=5.6.7.8; host=example.com:8080"}},
+			},
+
+			{"set Forwarded with localIP and HTTPS",
+				&http.Request{RemoteAddr: "1.2.3.4:5555", Host: "example.com:8080", TLS: &tls.ConnectionState{}},
+				config.Proxy{LocalIP: "5.6.7.8"},
+				http.Header{"Forwarded": {"for=1.2.3.4; proto=https; by=5.6.7.8; host=example.com:8080"}},
+			},
+
+			{"extend Forwarded with localIP",
+				&http.Request{RemoteAddr: "1.2.3.4:5555", Host: "example.com:8080", Header: http.Header{"Forwarded": {"for=9.9.9.9; proto=http; by=8.8.8.8"}}},
+				config.Proxy{LocalIP: "5.6.7.8"},
+				http.Header{"Forwarded": {"for=9.9.9.9; proto=http; by=8.8.8.8; by=5.6.7.8; host=example.com:8080"}},
+			},
+		})
+}
+
+func Test_addTLSHeader(t *testing.T) {
+	executeHeaderTests(t, addTLSHeader,
+		headerTestset{
+			{"set tls header",
+				&http.Request{RemoteAddr: "1.2.3.4:5555", TLS: &tls.ConnectionState{}},
+				config.Proxy{TLSHeader: "Secure"},
+				http.Header{"Secure": {""}},
+			},
+
+			{"set tls header with value",
+				&http.Request{RemoteAddr: "1.2.3.4:5555", TLS: &tls.ConnectionState{}},
+				config.Proxy{TLSHeader: "Secure", TLSHeaderValue: "true"},
+				http.Header{"Secure": {"true"}},
+			},
+		})
+}
+
+func executeHeaderTests(t *testing.T, addFunc func(r *http.Request, cfg config.Proxy, remoteIP string), tests headerTestset) {
 	for i, tt := range tests {
+		remoteIP, _, _ := net.SplitHostPort(tt.r.RemoteAddr)
 		if tt.r.Header == nil {
 			tt.r.Header = http.Header{}
 		}
-
-		err := addHeaders(tt.r, tt.cfg)
-		if err != nil {
-			if got, want := err.Error(), tt.err; got != want {
-				t.Errorf("%d: got %q want %q", i, got, want)
-			}
-			continue
-		}
-		if tt.err != "" {
-			t.Errorf("%d: got nil want %q", i, tt.err)
-			continue
-		}
+		addFunc(tt.r, tt.cfg, remoteIP)
 		if got, want := tt.r.Header, tt.hdrs; !reflect.DeepEqual(got, want) {
-			t.Errorf("%d: got %v want %v", i, got, want)
+			t.Errorf("%d: %s\ngot  %v\nwant %v", i, tt.desc, got, want)
 		}
 	}
+
 }


### PR DESCRIPTION
I had to add the X-Forwarded-Proto header to get fabio working as reverse proxy for the docker-registry with tls. While doing this, I made a more broaden overwork on the proxy headers.

So, here is a proposal for additional handling of proxy headers:
1. I changed the Host header for outgoing calls to reflect the host of the target service. This is e.g. essential if the target host serves different virtual hosts on the same ip.
2. I added the X-Real-Ip, X-Forwarded-Host, X-Forwarded-Proto headers, as they are the widely used.
3. I added the host attribute to Forwarded header. 
4. I removed the X-Forwaded-For header in the addHeaders method, because the golang reverse proxy already adds this header and we should not double the entries. (This changes the existing behavior, since the LocalIp is no longer part in the X-Forwaded-For, now.)

Please let me know, what you think about this. If you have any remarks on this, feel free to formulate your wishes and I will overwork the pull request.

(I'm also thinking about an integration test for the headers, which show the combined result of the addHeaders() and the Golang Reverse Proxy - but I was not sure, if you would like tests which test more than one unit.)