### PR TITLE
modifier: adding modifier tag concept

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/eBay/fabio/config"
@@ -50,6 +51,16 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// h = newWSProxy(t.URL)
 	default:
 		h = newHTTPProxy(t.URL, p.tr)
+	}
+
+	// strip the prefix, if the target was tagged properly
+	if t.StripPrefix {
+		pieces := strings.SplitN(r.URL.Path, "/", 3)
+		if len(pieces) == 3 {
+			r.URL.Path = pieces[2]
+		} else {
+			r.URL.Path = "/"
+		}
 	}
 
 	start := time.Now()

--- a/route/target.go
+++ b/route/target.go
@@ -16,6 +16,9 @@ type Target struct {
 	// URL is the endpoint the service instance listens on
 	URL *url.URL
 
+	// whether or not to strip the service prefix
+	StripPrefix bool
+
 	// FixedWeight is the weight assigned to this target.
 	// If the value is 0 the targets weight is dynamic.
 	FixedWeight float64


### PR DESCRIPTION
When digging into fabio, I found the need to be able to route to upstreams based upon a "prefix" in a URI.

For instance, let's say I have a service I want to call `test` at `localhost:8000` and I want it accessible at `localhost:9999/test/` via fabio. I would like a request to `localhost:9999/test` to point to `localhost:8000/`, not `localhost:8000/test`.

I added the concept of a "modifier" tag, which allows you to trigger whether or not we strip the prefix when routing to a specific target. I'd love to hear any thoughts, its my first steps in this code base and I'm sure there are plenty of things to do better!
