### PR TITLE
Expose the docker ports in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM scratch
 ADD build/ca-certificates.crt /etc/ssl/certs/
 ADD fabio.properties /etc/fabio/fabio.properties
 ADD fabio /
+EXPOSE 9998 9999
 CMD ["/fabio", "-cfg", "/etc/fabio/fabio.properties"]


### PR DESCRIPTION
Small improvement: It is good practice, to expose the docker ports explicitly.