### PR TITLE
Allow you to combine custom metrics prefix with default prefix.

### DIFF
--- a/fabio.properties
+++ b/fabio.properties
@@ -242,6 +242,11 @@
 #
 # When set to "default" the prefix is <hostname>.<executable>
 #
+# You hape option to combine custom prefix with default if metrics using  namespaces
+# Example: 
+#   'dev.default' will be converted to prefix as follow 'dev.<hostname>.<executable>'
+#
+#
 # The default is
 #
 # metrics.prefix = default

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -34,8 +34,8 @@ func Init(cfgs []config.Metrics) error {
 
 func initMetrics(cfg config.Metrics) error {
 	pfx = cfg.Prefix
-	if pfx == "default" {
-		pfx = defaultPrefix()
+	if strings.Contains(pfx, "default") {
+		pfx = strings.Replace(pfx, "default", defaultPrefix(), 1)
 	}
 
 	switch cfg.Target {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -44,10 +44,9 @@ func Init(cfgs []config.Metrics) error {
 func initMetrics(cfg config.Metrics) error {
 	pfx = cfg.Prefix
 	prefix := initPrefixTemplate()
-	if strings.Contains(pfx, "default") {
-		pfx = strings.Replace(pfx, "default", defaultPrefix(), 1)
+	if pfx == "default" {
+		pfx = defaultPrefix()
 	} else {
-
 		t := template.New("Prefix template")
 		t, err := t.Parse(pfx)
 		if err != nil {


### PR DESCRIPTION
Very useful when you have single Graphite and split environments with namespaces.

`metrics.prefix = myNameSpace.default`
  Example:
    '`dev.default`' will be converted to prefix as follow '`dev.<hostname>.<executable>`'
    '`qa.default`' will be converted to prefix as follow '`qa.<hostname>.<executable>`'
    '`prod.default`' will be converted to prefix as follow '`prod.<hostname>.<executable>`'

