### PR TITLE
Allow routes to a service in warning status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/fabio-*
 *-amd64
 .vagrant
 *.sha256
+.idea

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,7 @@ type Consul struct {
 	ServiceAddr   string
 	ServiceName   string
 	ServiceTags   []string
+	ServiceStatus []string
 	CheckInterval time.Duration
 	CheckTimeout  time.Duration
 }

--- a/config/default.go
+++ b/config/default.go
@@ -23,6 +23,7 @@ var Default = &Config{
 			Register:      true,
 			ServiceAddr:   ":9998",
 			ServiceName:   "fabio",
+			ServiceStatus: []string{"passing"},
 			CheckInterval: time.Second,
 			CheckTimeout:  3 * time.Second,
 		},

--- a/config/load.go
+++ b/config/load.go
@@ -81,6 +81,7 @@ func fromProperties(p *properties.Properties) (cfg *Config, err error) {
 			ServiceAddr:   stringVal(p, Default.Registry.Consul.ServiceAddr, "registry.consul.register.addr"),
 			ServiceName:   stringVal(p, Default.Registry.Consul.ServiceName, "registry.consul.register.name", "consul.register.name"),
 			ServiceTags:   stringAVal(p, Default.Registry.Consul.ServiceTags, "registry.consul.register.tags"),
+			ServiceStatus: stringAVal(p, Default.Registry.Consul.ServiceStatus, "registry.consul.service.status"),
 			CheckInterval: durationVal(p, Default.Registry.Consul.CheckInterval, "registry.consul.register.checkInterval", "consul.register.checkInterval"),
 			CheckTimeout:  durationVal(p, Default.Registry.Consul.CheckTimeout, "registry.consul.register.checkTimeout", "consul.register.checkTimeout"),
 		},

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -39,6 +39,7 @@ registry.consul.register.name = fab
 registry.consul.register.tags = a, b, c ,
 registry.consul.register.checkInterval = 5s
 registry.consul.register.checkTimeout = 10s
+registry.consul.service.status = a,b
 metrics.target = graphite
 metrics.prefix = someprefix
 metrics.interval = 5s
@@ -81,6 +82,7 @@ ui.title = fabfab
 				ServiceAddr:   "6.6.6.6:7777",
 				ServiceName:   "fab",
 				ServiceTags:   []string{"a", "b", "c"},
+				ServiceStatus: []string{"a", "b"},
 				CheckInterval: 5 * time.Second,
 				CheckTimeout:  10 * time.Second,
 			},

--- a/fabio.properties
+++ b/fabio.properties
@@ -4,7 +4,7 @@
 # To configure an HTTPS listener provide [host]:port;certFile;keyFile;clientAuthFile.
 # certFile and keyFile contain the public/private key pair for that listener
 # in PEM format. If certFile contains both the public and private key then
-# keyFile can be omittted.
+# keyFile can be omitted.
 # clientAuthFile contains the root CAs for client certificate validation.
 # When clientAuthFile is provided the TLS configuration is set to
 # RequireAndVerifyClientCert.
@@ -187,6 +187,17 @@
 # registry.consul.kvpath = /fabio/config
 
 
+# registry.consul.service.status configures the valid service status
+# values for services included in the routing table.
+#
+# The values are a comma separated list of
+# "passing", "warning", "critical" and "unknown"
+#
+# The default is
+#
+# registry.consul.service.status = passing
+
+
 # registry.consul.tagprefix configures the prefix for tags which define routes.
 #
 # Services which define routes publish one or more tags with host/path
@@ -302,7 +313,7 @@
 # runtime.gogc configures GOGC (the GC target percentage).
 #
 # Setting runtime.gogc is equivalent to setting the GOGC
-# environment variable which also takes precendence over
+# environment variable which also takes precedence over
 # the value from the config file.
 #
 # Increasing this value means fewer but longer GC cycles
@@ -318,7 +329,7 @@
 #
 # GOGC=100: Go 1.5 40% slower than Go 1.4
 # GOGC=200: Go 1.5 == Go 1.4 with GOGC=100 (default)
-# GOGC=800: both Go 1.4 and 1.5 significanlty faster (40%/go1.4, 100%/go1.5)
+# GOGC=800: both Go 1.4 and 1.5 significantly faster (40%/go1.4, 100%/go1.5)
 #
 # The default is
 #
@@ -328,7 +339,7 @@
 # runtime.gomaxprocs configures GOMAXPROCS.
 #
 # Setting runtime.gomaxprocs is equivalent to setting the GOMAXPROCS
-# environment variable which also takes precendence over
+# environment variable which also takes precedence over
 # the value from the config file.
 #
 # If runtime.gomaxprocs < 0 then all CPU cores are used.

--- a/registry/consul/backend.go
+++ b/registry/consul/backend.go
@@ -80,7 +80,7 @@ func (b *be) WatchServices() chan string {
 	log.Printf("[INFO] consul: Using tag prefix %q", b.cfg.TagPrefix)
 
 	svc := make(chan string)
-	go watchServices(b.c, b.cfg.TagPrefix, svc)
+	go watchServices(b.c, b.cfg.TagPrefix, b.cfg.ServiceStatus, svc)
 	return svc
 }
 

--- a/registry/consul/passing.go
+++ b/registry/consul/passing.go
@@ -10,7 +10,7 @@ import (
 // passingServices filters out health checks for services which have
 // passing health checks and where the neither the service instance itself
 // nor the node is in maintenance mode.
-func passingServices(checks []*api.HealthCheck) []*api.HealthCheck {
+func passingServices(checks []*api.HealthCheck, status []string) []*api.HealthCheck {
 	var p []*api.HealthCheck
 	for _, svc := range checks {
 		// first filter out non-service checks
@@ -19,7 +19,7 @@ func passingServices(checks []*api.HealthCheck) []*api.HealthCheck {
 		}
 
 		// then make sure the service health check is passing
-		if svc.Status != "passing" {
+		if !contains(status, svc.Status) {
 			continue
 		}
 
@@ -46,4 +46,13 @@ func passingServices(checks []*api.HealthCheck) []*api.HealthCheck {
 	}
 
 	return p
+}
+
+func contains(slice []string, item string) bool {
+	for _, a := range slice {
+		if a == item {
+			return true
+		}
+	}
+	return false
 }

--- a/registry/consul/passing_test.go
+++ b/registry/consul/passing_test.go
@@ -12,6 +12,8 @@ func TestPassingServices(t *testing.T) {
 		serfPass     = &api.HealthCheck{Node: "node", CheckID: "serfHealth", Status: "passing"}
 		serfFail     = &api.HealthCheck{Node: "node", CheckID: "serfHealth", Status: "critical"}
 		svc1Pass     = &api.HealthCheck{Node: "node", CheckID: "service:abc", Status: "passing", ServiceName: "abc", ServiceID: "abc-1"}
+		svc1Warn     = &api.HealthCheck{Node: "node", CheckID: "service:abc", Status: "warning", ServiceName: "abc", ServiceID: "abc-2"}
+		svc1Crit     = &api.HealthCheck{Node: "node", CheckID: "service:abc", Status: "critical", ServiceName: "abc", ServiceID: "abc-3"}
 		svc2Pass     = &api.HealthCheck{Node: "node", CheckID: "my-check-id", Status: "passing", ServiceName: "def", ServiceID: "def-1"}
 		svc1Maint    = &api.HealthCheck{Node: "node", CheckID: "_service_maintenance:abc-1", Status: "critical", ServiceName: "abc", ServiceID: "abc-1"}
 		svc1ID2Maint = &api.HealthCheck{Node: "node", CheckID: "_service_maintenance:abc-2", Status: "critical", ServiceName: "abc", ServiceID: "abc-2"}
@@ -19,24 +21,29 @@ func TestPassingServices(t *testing.T) {
 	)
 
 	tests := []struct {
+		status  []string
 		in, out []*api.HealthCheck
 	}{
-		{nil, nil},
-		{[]*api.HealthCheck{}, nil},
-		{[]*api.HealthCheck{svc1Pass}, []*api.HealthCheck{svc1Pass}},
-		{[]*api.HealthCheck{svc1Pass, svc2Pass}, []*api.HealthCheck{svc1Pass, svc2Pass}},
-		{[]*api.HealthCheck{serfPass, svc1Pass}, []*api.HealthCheck{svc1Pass}},
-		{[]*api.HealthCheck{serfFail, svc1Pass}, nil},
-		{[]*api.HealthCheck{nodeMaint, svc1Pass}, nil},
-		{[]*api.HealthCheck{svc1Maint, svc1Pass}, nil},
-		{[]*api.HealthCheck{nodeMaint, svc1Maint, svc1Pass}, nil},
-		{[]*api.HealthCheck{serfFail, nodeMaint, svc1Maint, svc1Pass}, nil},
-		{[]*api.HealthCheck{svc1ID2Maint, svc1Pass}, []*api.HealthCheck{svc1Pass}},
-		{[]*api.HealthCheck{svc1Maint, svc1Pass, svc2Pass}, []*api.HealthCheck{svc2Pass}},
+		{[]string{"passing"}, nil, nil},
+		{[]string{"passing"}, []*api.HealthCheck{}, nil},
+		{[]string{"passing"}, []*api.HealthCheck{svc1Pass}, []*api.HealthCheck{svc1Pass}},
+		{[]string{"passing"}, []*api.HealthCheck{svc1Pass, svc2Pass}, []*api.HealthCheck{svc1Pass, svc2Pass}},
+		{[]string{"passing"}, []*api.HealthCheck{serfPass, svc1Pass}, []*api.HealthCheck{svc1Pass}},
+		{[]string{"passing"}, []*api.HealthCheck{serfFail, svc1Pass}, nil},
+		{[]string{"passing"}, []*api.HealthCheck{nodeMaint, svc1Pass}, nil},
+		{[]string{"passing"}, []*api.HealthCheck{svc1Maint, svc1Pass}, nil},
+		{[]string{"passing"}, []*api.HealthCheck{nodeMaint, svc1Maint, svc1Pass}, nil},
+		{[]string{"passing"}, []*api.HealthCheck{serfFail, nodeMaint, svc1Maint, svc1Pass}, nil},
+		{[]string{"passing"}, []*api.HealthCheck{svc1ID2Maint, svc1Pass}, []*api.HealthCheck{svc1Pass}},
+		{[]string{"passing"}, []*api.HealthCheck{svc1Maint, svc1Pass, svc2Pass}, []*api.HealthCheck{svc2Pass}},
+		{[]string{"passing", "warning"}, []*api.HealthCheck{serfPass, svc1Pass, svc1Crit}, []*api.HealthCheck{svc1Pass}},
+		{[]string{"passing", "warning"}, []*api.HealthCheck{serfPass, svc1Warn, svc1Crit}, []*api.HealthCheck{svc1Warn}},
+		{[]string{"passing", "warning"}, []*api.HealthCheck{serfPass, svc1Pass, svc1Warn}, []*api.HealthCheck{svc1Pass, svc1Warn}},
+		{[]string{"passing", "warning"}, []*api.HealthCheck{serfPass, svc1Warn, svc1Crit, svc1Pass}, []*api.HealthCheck{svc1Warn, svc1Pass}},
 	}
 
 	for i, tt := range tests {
-		if got, want := passingServices(tt.in), tt.out; !reflect.DeepEqual(got, want) {
+		if got, want := passingServices(tt.in, tt.status), tt.out; !reflect.DeepEqual(got, want) {
 			t.Errorf("%d: got %v want %v", i, got, want)
 		}
 	}

--- a/registry/consul/service.go
+++ b/registry/consul/service.go
@@ -13,7 +13,7 @@ import (
 
 // watchServices monitors the consul health checks and creates a new configuration
 // on every change.
-func watchServices(client *api.Client, tagPrefix string, config chan string) {
+func watchServices(client *api.Client, tagPrefix string, status []string, config chan string) {
 	var lastIndex uint64
 
 	for {
@@ -26,7 +26,7 @@ func watchServices(client *api.Client, tagPrefix string, config chan string) {
 		}
 
 		log.Printf("[INFO] consul: Health changed to #%d", meta.LastIndex)
-		config <- servicesConfig(client, passingServices(checks), tagPrefix)
+		config <- servicesConfig(client, passingServices(checks, status), tagPrefix)
 		lastIndex = meta.LastIndex
 	}
 }


### PR DESCRIPTION
Currently Fabio only creates routes to services in the passing state. We have a use case for also wanting to use services in warning status. In consul the warning status indicates that the service is still good to go, but requires attention to keep it that way.

In this PR the acceptable statuses can be configured in fabio.properties where the default is just "passing" for backward compatibility.

As a bonus a few minor typos were fixed.

Unlike my previous attempt ( #116 ) this PR has a single squashed commit.