### PR TITLE
Minimal POC of SSE support

### DIFF
--- a/proxy/httpsse.go
+++ b/proxy/httpsse.go
@@ -1,0 +1,15 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+)
+
+func newHTTPSSEProxy(t *url.URL, tr http.RoundTripper) http.Handler {
+	rp := httputil.NewSingleHostReverseProxy(t)
+	rp.Transport = tr
+	rp.FlushInterval = 5 * time.Second
+	return rp
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -48,6 +48,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// To use the filtered proxy use
 		// h = newWSProxy(t.URL)
+	case r.Header.Get("Accept") == "text/event-stream":
+		h = newHTTPSSEProxy(t.URL, p.tr)
+
 	default:
 		h = newHTTPProxy(t.URL, p.tr)
 	}


### PR DESCRIPTION
I'm not actually a developer, least of all in Go. Also, I just chose the interval semi-randomly from some reference implementation of SSE in Go.

Apart from that the protocol stipulates that the Accept header isn't exactly mandatory, but the response must have a Content-Type of type/event-stream, though I have a feeling that would be too late in the process to define the FlushBuffer.