### PR TITLE
Update parse.go

### DIFF
--- a/registry/consul/parse.go
+++ b/registry/consul/parse.go
@@ -18,7 +18,7 @@ func parseURLPrefixTag(s, prefix string, env map[string]string) (host, path stri
 	// split host/path
 	p := strings.SplitN(s[len(prefix):], "/", 2)
 	if len(p) != 2 {
-		log.Printf("[WARN] consul: Invalid %s tag %q", prefix, s)
+		log.Printf("[WARN] consul: Invalid %s tag %q - You need to have a trailing slash!", prefix, s)
 		return "", "", false
 	}
 


### PR DESCRIPTION
The error text when you don't have a trailing slash isn't clear. This is to make it super-obvious!