### PR TITLE
Make route metric names configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,16 +68,17 @@ type Runtime struct {
 }
 
 type Metrics struct {
-	Target           string
-	Prefix           string
-	Interval         time.Duration
-	GraphiteAddr     string
-	StatsDAddr       string
-	CirconusAPIKey   string
-	CirconusAPIApp   string
-	CirconusAPIURL   string
-	CirconusCheckID  string
-	CirconusBrokerID string
+	Target                  string
+	Prefix                  string
+	Interval                time.Duration
+	GraphiteAddr            string
+	StatsDAddr              string
+	CirconusAPIKey          string
+	CirconusAPIApp          string
+	CirconusAPIURL          string
+	CirconusCheckID         string
+	CirconusBrokerID        string
+	RouteMetricNameTemplate string
 }
 
 type Registry struct {

--- a/config/default.go
+++ b/config/default.go
@@ -40,9 +40,10 @@ var Default = &Config{
 		Color: "light-green",
 	},
 	Metrics: Metrics{
-		Prefix:         "default",
-		Interval:       30 * time.Second,
-		CirconusAPIApp: "fabio",
+		Prefix:                  "default",
+		Interval:                30 * time.Second,
+		CirconusAPIApp:          "fabio",
+		RouteMetricNameTemplate: "$service$.$host$.$path$.$target$",
 	},
 	CertSources: map[string]CertSource{},
 }

--- a/config/default.go
+++ b/config/default.go
@@ -43,7 +43,7 @@ var Default = &Config{
 		Prefix:                  "default",
 		Interval:                30 * time.Second,
 		CirconusAPIApp:          "fabio",
-		RouteMetricNameTemplate: "$service$.$host$.$path$.$target$",
+		RouteMetricNameTemplate: "{{clean .Service}}.{{clean .Host}}.{{clean .Path}}.{{clean .TargetURL.Host}}",
 	},
 	CertSources: map[string]CertSource{},
 }

--- a/config/load.go
+++ b/config/load.go
@@ -115,6 +115,7 @@ func load(p *properties.Properties) (cfg *Config, err error) {
 	f.StringVar(&cfg.Metrics.CirconusAPIURL, "metrics.circonus.apiurl", Default.Metrics.CirconusAPIURL, "Circonus API URL")
 	f.StringVar(&cfg.Metrics.CirconusBrokerID, "metrics.circonus.brokerid", Default.Metrics.CirconusBrokerID, "Circonus Broker ID")
 	f.StringVar(&cfg.Metrics.CirconusCheckID, "metrics.circonus.checkid", Default.Metrics.CirconusCheckID, "Circonus Check ID")
+	f.StringVar(&cfg.Metrics.RouteMetricNameTemplate, "metrics.routemetricnametemplate", Default.Metrics.RouteMetricNameTemplate, "route metric name template")
 	f.StringVar(&cfg.Registry.Backend, "registry.backend", Default.Registry.Backend, "registry backend")
 	f.StringVar(&cfg.Registry.File.Path, "registry.file.path", Default.Registry.File.Path, "path to file based routing table")
 	f.StringVar(&cfg.Registry.Static.Routes, "registry.static.routes", Default.Registry.Static.Routes, "static routes")

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -53,6 +53,7 @@ metrics.circonus.apiapp = circonus-apiapp
 metrics.circonus.apiurl = circonus-apiurl
 metrics.circonus.brokerid = circonus-brokerid
 metrics.circonus.checkid = circonus-checkid
+metrics.routemetricnametemplate = $service$.$host$.$path$.$target$
 runtime.gogc = 666
 runtime.gomaxprocs = 12
 ui.addr = 7.8.9.0:1234
@@ -123,16 +124,17 @@ aws.apigw.cert.cn = furb
 			},
 		},
 		Metrics: Metrics{
-			Target:           "graphite",
-			Prefix:           "someprefix",
-			Interval:         5 * time.Second,
-			GraphiteAddr:     "5.6.7.8:9999",
-			StatsDAddr:       "6.7.8.9:9999",
-			CirconusAPIKey:   "circonus-apikey",
-			CirconusAPIApp:   "circonus-apiapp",
-			CirconusAPIURL:   "circonus-apiurl",
-			CirconusBrokerID: "circonus-brokerid",
-			CirconusCheckID:  "circonus-checkid",
+			Target:                  "graphite",
+			Prefix:                  "someprefix",
+			Interval:                5 * time.Second,
+			GraphiteAddr:            "5.6.7.8:9999",
+			StatsDAddr:              "6.7.8.9:9999",
+			CirconusAPIKey:          "circonus-apikey",
+			CirconusAPIApp:          "circonus-apiapp",
+			CirconusAPIURL:          "circonus-apiurl",
+			CirconusBrokerID:        "circonus-brokerid",
+			CirconusCheckID:         "circonus-checkid",
+			RouteMetricNameTemplate: "$service$.$host$.$path$.$target$",
 		},
 		Runtime: Runtime{
 			GOGC:       666,

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -53,7 +53,7 @@ metrics.circonus.apiapp = circonus-apiapp
 metrics.circonus.apiurl = circonus-apiurl
 metrics.circonus.brokerid = circonus-brokerid
 metrics.circonus.checkid = circonus-checkid
-metrics.routemetricnametemplate = $service$.$host$.$path$.$target$
+metrics.routemetricnametemplate = {{clean .Service}}.{{clean .Host}}.{{clean .Path}}.{{clean .TargetURL.Host}}
 runtime.gogc = 666
 runtime.gomaxprocs = 12
 ui.addr = 7.8.9.0:1234
@@ -134,7 +134,7 @@ aws.apigw.cert.cn = furb
 			CirconusAPIURL:          "circonus-apiurl",
 			CirconusBrokerID:        "circonus-brokerid",
 			CirconusCheckID:         "circonus-checkid",
-			RouteMetricNameTemplate: "$service$.$host$.$path$.$target$",
+			RouteMetricNameTemplate: "{{clean .Service}}.{{clean .Host}}.{{clean .Path}}.{{clean .TargetURL.Host}}",
 		},
 		Runtime: Runtime{
 			GOGC:       666,

--- a/fabio.properties
+++ b/fabio.properties
@@ -571,10 +571,12 @@
 # Given a route rule of: route add testservice www.example.com/ http://10.1.2.3:12345/
 # The template variables would be:
 #
-# $service$=testservice
-# $host$=www_example_com
-# $path$=/
-# $target$=10_1_2_3_12345
+# .Service = testservice
+# .Host = www.example.com
+# .Path  = /
+# .TargetURL.Host = 10.1.2.3:12345
+#
+# Function: clean - lowercases value and replaces '.' and ':' with '_'
 #
 # The resulting metric name (using the default template):
 #
@@ -582,7 +584,7 @@
 #
 # The default is
 #
-# metrics.routemetricnametemplate = $service$.$host$.$path$.$target$
+# metrics.routemetricnametemplate = {{clean .Service}}.{{clean .Host}}.{{clean .Path}}.{{clean .TargetURL.Host}}
 
 
 # runtime.gogc configures GOGC (the GC target percentage).

--- a/fabio.properties
+++ b/fabio.properties
@@ -564,6 +564,27 @@
 # metrics.circonus.checkid =
 
 
+# metrics.routemetricnametemplate provides the ability to customize
+# the route metric names. Variables available for template expansion
+# are: service host path and target.
+#
+# Given a route rule of: route add testservice www.example.com/ http://10.1.2.3:12345/
+# The template variables would be:
+#
+# $service$=testservice
+# $host$=www_example_com
+# $path$=/
+# $target$=10_1_2_3_12345
+#
+# The resulting metric name (using the default template):
+#
+# testservice.www_example_com./.10_1_2_3_12345
+#
+# The default is
+#
+# metrics.routemetricnametemplate = $service$.$host$.$path$.$target$
+
+
 # runtime.gogc configures GOGC (the GC target percentage).
 #
 # Setting runtime.gogc is equivalent to setting the GOGC

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,12 +19,16 @@ import (
 // DefaultRegistry stores the metrics library provider.
 var DefaultRegistry Registry = NoopRegistry{}
 
+var routeMetricNameTemplate string
+
 // NewRegistry creates a new metrics registry.
 func NewRegistry(cfg config.Metrics) (r Registry, err error) {
 	prefix := cfg.Prefix
 	if prefix == "default" {
 		prefix = defaultPrefix()
 	}
+
+	routeMetricNameTemplate = cfg.RouteMetricNameTemplate
 
 	switch cfg.Target {
 	case "stdout":
@@ -56,12 +60,13 @@ func NewRegistry(cfg config.Metrics) (r Registry, err error) {
 
 // TargetName returns the metrics name from the given parameters.
 func TargetName(service, host, path string, targetURL *url.URL) string {
-	return strings.Join([]string{
-		clean(service),
-		clean(host),
-		clean(path),
-		clean(targetURL.Host),
-	}, ".")
+	name := routeMetricNameTemplate
+	name = strings.Replace(name, "$service$", clean(service), -1)
+	name = strings.Replace(name, "$host$", clean(host), -1)
+	name = strings.Replace(name, "$path$", clean(path), -1)
+	name = strings.Replace(name, "$target$", clean(targetURL.Host), -1)
+
+	return name
 }
 
 // clean creates safe names for graphite reporting by replacing

--- a/route/route.go
+++ b/route/route.go
@@ -46,7 +46,7 @@ func (r *Route) addTarget(service string, targetURL *url.URL, fixedWeight float6
 		fixedWeight = 0
 	}
 
-	name := metrics.TargetName(service, r.Host, r.Path, targetURL)
+	name, _ := metrics.TargetName(service, r.Host, r.Path, targetURL)
 	timer := ServiceRegistry.GetTimer(name)
 
 	t := &Target{Service: service, Tags: tags, URL: targetURL, FixedWeight: fixedWeight, Timer: timer, timerName: name}


### PR DESCRIPTION
Had request for the ability to alter the route metric names coming out of the clusters with nomad/consul testing. e.g.

```go
package main

import (
	"fmt"
	"net/url"
	"strings"
)

func clean(s string) string {
	if s == "" {
		return "_"
	}
	s = strings.Replace(s, ".", "_", -1)
	s = strings.Replace(s, ":", "_", -1)
	return strings.ToLower(s)
}

func TargetName(template string, service string, host string, path string, targetURL *url.URL) string {
	name := template
	name = strings.Replace(name, "$service$", clean(service), -1)
	name = strings.Replace(name, "$host$", clean(host), -1)
	name = strings.Replace(name, "$path$", clean(path), -1)
	name = strings.Replace(name, "$target$", clean(targetURL.Host), -1)

	return name
}

func main() {

	// given a route rule of: route add hashiapp hashiapp.com/ http://10.1.2.3:12345/
	service := "hashiapp"
	host := "hashiapp.com"
	path := "/"
	target, err := url.Parse("http://10.1.2.3:12345")
	if err != nil {
		panic(err)
	}

	/* default template
	 *
	 * metrics.routemetricnametemplate = $service$.$host$.$path$.$target$
	 *
	 */

	template := "$service$.$host$.$path$.$target$"
	fmt.Printf("Default route metric name: %s\n", TargetName(template, service, host, path, target))

	template = "$service$.$host$.$path$"
	fmt.Printf("Custom route metric name : %s\n", TargetName(template, service, host, path, target))

	template = "$service$.$host$.$path$.latency_ns"
	fmt.Printf("Custom route metric name : %s\n", TargetName(template, service, host, path, target))

}
```  

```
⁖ go run test.go
Default route metric name: hashiapp.hashiapp_com./.10_1_2_3_12345
Custom route metric name : hashiapp.hashiapp_com./
Custom route metric name : hashiapp.hashiapp_com./.latency_ns
```