### PR TITLE
Metrics Prefix with templates

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -40,7 +40,7 @@ var Default = &Config{
 		Color: "light-green",
 	},
 	Metrics: Metrics{
-		Prefix:         "{{clean .Hostname}}.{{clean .Exe}}",
+		Prefix:         "{{clean .Hostname}}.{{clean .Exec}}",
 		Names:          "{{clean .Service}}.{{clean .Host}}.{{clean .Path}}.{{clean .TargetURL.Host}}",
 		Interval:       30 * time.Second,
 		CirconusAPIApp: "fabio",

--- a/config/default.go
+++ b/config/default.go
@@ -40,7 +40,7 @@ var Default = &Config{
 		Color: "light-green",
 	},
 	Metrics: Metrics{
-		Prefix:         "default",
+		Prefix:         "{{clean .Hostname}}.{{clean .Exe}}",
 		Names:          "{{clean .Service}}.{{clean .Host}}.{{clean .Path}}.{{clean .TargetURL.Host}}",
 		Interval:       30 * time.Second,
 		CirconusAPIApp: "fabio",

--- a/fabio.properties
+++ b/fabio.properties
@@ -506,7 +506,8 @@
 #
 #    prefix.service.host.path.target-addr
 #
-# Available variables for prefix:
+# The value is expanded by the text/template package and provides
+# the following variables:
 #
 #  - Hostname:  the Hostname of the server
 #  - Exec:      the executable name of application
@@ -515,21 +516,22 @@
 #
 #  - clean:     lowercase value and replace '.' and ':' with '_'
 #
-# For example server hostname is:
+# Template may include regular string parts to customize final prefix
 #
-#  test-001.something.com
+# Example:
 #
-# When using the default template prefix will be as:
+#  Server hostname: test-001.something.com
+#  Binary executable name: fabio
+#
+#  The template variables are:
+#
+#  .Hostname =  test-001.something.com
+#  .Exec = fabio
+#
+# which results to the following prefix string when using the
+# default template:
 #
 #  test-001_something_com.fabio
-#
-#
-# At allow us add additional custom string Tags to any place of the prefix for customuzation:
-#
-# Template:   MyTag.{{clean .Hostname}}.{{clean .Exe}}
-#
-# Result:     MyTag.test-001_something_com.fabio
-#
 #
 # The default is
 #

--- a/fabio.properties
+++ b/fabio.properties
@@ -533,7 +533,7 @@
 #
 # The default is
 #
-# metrics.prefix = {{clean .Hostname}}.{{clean .Exe}}
+# metrics.prefix = {{clean .Hostname}}.{{clean .Exec}}
 
 
 # metrics.names configures the template for the route metric names.

--- a/fabio.properties
+++ b/fabio.properties
@@ -500,22 +500,40 @@
 # metrics.target =
 
 
-# metrics.prefix configures the prefix of all reported metrics.
+# metrics.prefix configures the template for the prefix of all reported metrics.
 #
 # Each metric has a unique name which is hard-coded to
 #
 #    prefix.service.host.path.target-addr
 #
-# When set to "default" the prefix is <hostname>.<executable>
+# Available variables for prefix:
 #
-# You hape option to combine custom prefix with default if metrics using  namespaces
-# Example: 
-#   'dev.default' will be converted to prefix as follow 'dev.<hostname>.<executable>'
+#  - Hostname:  the Hostname of the server
+#  - Exec:      the executable name of application
+#
+# The following additional functions are defined:
+#
+#  - clean:     lowercase value and replace '.' and ':' with '_'
+#
+# For example server hostname is:
+#
+#  test-001.something.com
+#
+# When using the default template prefix will be as:
+#
+#  test-001_something_com.fabio
+#
+#
+# At allow us add additional custom string Tags to any place of the prefix for customuzation:
+#
+# Template:   MyTag.{{clean .Hostname}}.{{clean .Exe}}
+#
+# Result:     MyTag.test-001_something_com.fabio
 #
 #
 # The default is
 #
-# metrics.prefix = default
+# metrics.prefix = {{clean .Hostname}}.{{clean .Exe}}
 
 
 # metrics.names configures the template for the route metric names.

--- a/fabio.properties
+++ b/fabio.properties
@@ -508,6 +508,11 @@
 #
 # When set to "default" the prefix is <hostname>.<executable>
 #
+# You hape option to combine custom prefix with default if metrics using  namespaces
+# Example: 
+#   'dev.default' will be converted to prefix as follow 'dev.<hostname>.<executable>'
+#
+#
 # The default is
 #
 # metrics.prefix = default

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -25,6 +25,9 @@ var DefaultRegistry Registry = NoopRegistry{}
 // DefaultNames contains the default template for route metric names.
 const DefaultNames = "{{clean .Service}}.{{clean .Host}}.{{clean .Path}}.{{clean .TargetURL.Host}}"
 
+// DefaulPrefix contains the default template for metrics prefix.
+const DefaultPrefix = "{{clean .Hostname}}.{{clean .Exec}}"
+
 // names stores the template for the route metric names.
 var names *template.Template
 
@@ -80,6 +83,10 @@ func NewRegistry(cfg config.Metrics) (r Registry, err error) {
 
 // parsePrefix parses the prefix metric template
 func parsePrefix(tmpl string) (string, error) {
+	// Backward compatibility condition for old metrics.prefix parameter 'default'
+	if tmpl == "default" {
+		tmpl = DefaultPrefix
+	}
 	funcMap := template.FuncMap{
 		"clean": clean,
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -41,10 +41,6 @@ func init() {
 
 // NewRegistry creates a new metrics registry.
 func NewRegistry(cfg config.Metrics) (r Registry, err error) {
-	// prefix := cfg.Prefix
-	// if prefix == "default" {
-	// 	prefix = defaultPrefix()
-	// }
 
 	if prefix, err = parsePrefix(cfg.Prefix); err != nil {
 		return nil, fmt.Errorf("metrics: invalid Prefix template. %s", err)
@@ -162,14 +158,3 @@ func clean(s string) string {
 
 // stubbed out for testing
 var hostname = os.Hostname
-
-// defaultPrefix determines the default metrics prefix from
-// the current hostname and the name of the executable.
-func defaultPrefix() string {
-	host, err := hostname()
-	if err != nil {
-		exit.Fatal("[FATAL] ", err)
-	}
-	exe := filepath.Base(os.Args[0])
-	return clean(host) + "." + clean(exe)
-}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -6,10 +6,15 @@ import (
 	"testing"
 )
 
-func TestDefaultPrefix(t *testing.T) {
+func TestParsePrefix(t *testing.T) {
 	hostname = func() (string, error) { return "myhost", nil }
 	os.Args = []string{"./myapp"}
-	if got, want := defaultPrefix(), "myhost.myapp"; got != want {
+	got, err := parsePrefix("{{clean .Hostname}}.{{clean .Exe}}")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	want := "myhost.myapp"
+	if got != want {
 		t.Errorf("got %v want %v", got, want)
 	}
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -9,7 +9,7 @@ import (
 func TestParsePrefix(t *testing.T) {
 	hostname = func() (string, error) { return "myhost", nil }
 	os.Args = []string{"./myapp"}
-	got, err := parsePrefix("{{clean .Hostname}}.{{clean .Exe}}")
+	got, err := parsePrefix("{{clean .Hostname}}.{{clean .Exec}}")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -15,7 +15,16 @@ func TestParsePrefix(t *testing.T) {
 	}
 	want := "myhost.myapp"
 	if got != want {
-		t.Errorf("got %v want %v", got, want)
+		t.Errorf("ParsePrefix: got %v want %v", got, want)
+	}
+
+	got, err = parsePrefix("default")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	want = "myhost.myapp"
+	if got != want {
+		t.Errorf("ParsePrefix Old default style: got %v want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
This is actually same as https://github.com/eBay/fabio/pull/81
By mistake wiped out my brunch.
I removed modifications about external `hostname` execution, because it bit tricky to achieve same functionality across platforms, so i just moved `metrics.prefix` to templates same  way as  `metrics.names`.

```
# metrics.prefix configures the template for the prefix of all reported metrics.
#
# Each metric has a unique name which is hard-coded to
#
#    prefix.service.host.path.target-addr
#
# The value is expanded by the text/template package and provides
# the following variables:
#
#  - Hostname:  the Hostname of the server
#  - Exec:      the executable name of application
#
# The following additional functions are defined:
#
#  - clean:     lowercase value and replace '.' and ':' with '_'
#
# Template may include regular string parts to customize final prefix
#
# Example:
#
#  Server hostname: test-001.something.com
#  Binary executable name: fabio
#
#  The template variables are:
#
#  .Hostname =  test-001.something.com
#  .Exec = fabio
#
# which results to the following prefix string when using the
# default template:
#
#  test-001_something_com.fabio
#
# The default is
#
# metrics.prefix = {{clean .Hostname}}.{{clean .Exec}}
```