### PR TITLE
added glob host matching - fixes #163

### DIFF
--- a/route/table.go
+++ b/route/table.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
-	"regexp"
+	"path"
 	"sync"
 	"sync/atomic"
 
@@ -320,15 +320,17 @@ func (t Table) lookup(host, lookupPath, trace string) *Target {
 		return t.matchHostPath(host, lookupPath, trace)
 	}
 
-	/* // TODO if no regex configuration, just return this
+/*
+	// TODO if no regex configuration, just return this
 	// If the host is defined, run a search against that exact host name
 	var foundTarget = t.matchHostPath(host, lookupPath, trace)
 	if foundTarget != nil {
 		return foundTarget
 	}
-	*/
+*/
 
 	// TODO give an option for regex or glob host configuration
+	// think about how to do regex whether to inject ^$ etc.
 
 	// If the user wants to run regex search (TODO, do regex and make configuration)
 	// Create a new array of targets
@@ -338,7 +340,7 @@ func (t Table) lookup(host, lookupPath, trace string) *Target {
 	// then for each of those, run a path check, and add that entry into the routing table
 	for hostKey, _ := range t {
 		// If this matches a glob match, add it to the list of hosts to search
-		var hasMatch, err = regexp.MatchString(hostKey, host)
+		var hasMatch, err = path.Match(hostKey, host)
 
 		if err != nil {
 			log.Printf("[ERROR] Glob matching error %s for host %s vs %s", err, hostKey, host)

--- a/route/table.go
+++ b/route/table.go
@@ -320,21 +320,19 @@ func (t Table) lookup(host, lookupPath, trace string) *Target {
 		return t.matchHostPath(host, lookupPath, trace)
 	}
 
-/*
-	// TODO if no regex configuration, just return this
-	// If the host is defined, run a search against that exact host name
-	var foundTarget = t.matchHostPath(host, lookupPath, trace)
-	if foundTarget != nil {
-		return foundTarget
+	routes := Routes{}
+
+	// If there is a direct match, add that route as the first match
+	var foundRoute = t.matchHostPathRoute(host, lookupPath, trace)
+	if foundRoute != nil {
+		routes = append(routes, foundRoute)
 	}
-*/
 
 	// TODO give an option for regex or glob host configuration
 	// think about how to do regex whether to inject ^$ etc.
 
 	// If the user wants to run regex search (TODO, do regex and make configuration)
 	// Create a new array of targets
-	routes := Routes{}
 
 	// If not found against the host, perform a glob search against the hosts
 	// then for each of those, run a path check, and add that entry into the routing table
@@ -350,6 +348,7 @@ func (t Table) lookup(host, lookupPath, trace string) *Target {
 		if hasMatch {
 			var matchingRoute = t.matchHostPathRoute(hostKey, lookupPath, trace)
 			if matchingRoute != nil {
+				// Should only check for unique route (from above foundRoute)?
 				routes = append(routes, matchingRoute)
 			}
 		}

--- a/route/table_lookup_test.go
+++ b/route/table_lookup_test.go
@@ -35,6 +35,12 @@ func TestTableLookup(t *testing.T) {
 	route add svc abc.com/foo/ http://foo.com:2000
 	route add svc abc.com/foo/bar http://foo.com:2500
 	route add svc abc.com/foo/bar/ http://foo.com:3000
+	route add svc */widget http://foo.com:901
+	route add svc *.abc.com/ http://foo.com:1001
+	route add svc *.abc.com/foo http://foo.com:1501
+	route add svc *.abc.com/foo/ http://foo.com:2001
+	route add svc *.abc.com/foo/bar http://foo.com:2501
+	route add svc *.abc.com/foo/bar/ http://foo.com:3001
 	`
 
 	tbl, err := ParseString(s)
@@ -53,11 +59,22 @@ func TestTableLookup(t *testing.T) {
 		{&http.Request{Host: "abc.com", RequestURI: "/foo/"}, "http://foo.com:2000"},
 		{&http.Request{Host: "abc.com", RequestURI: "/foo/bar"}, "http://foo.com:2500"},
 		{&http.Request{Host: "abc.com", RequestURI: "/foo/bar/"}, "http://foo.com:3000"},
+		{&http.Request{Host: "abc.com", RequestURI: "/widget"}, "http://foo.com:901"},
+
+		// match on host and path with and without trailing slash using glob host match
+		{&http.Request{Host: "z.abc.com", RequestURI: "/"}, "http://foo.com:1001"},
+		{&http.Request{Host: "z.abc.com", RequestURI: "/bar"}, "http://foo.com:1001"},
+		{&http.Request{Host: "z.abc.com", RequestURI: "/foo"}, "http://foo.com:1501"},
+		{&http.Request{Host: "z.abc.com", RequestURI: "/foo/"}, "http://foo.com:2001"},
+		{&http.Request{Host: "z.abc.com", RequestURI: "/foo/bar"}, "http://foo.com:2501"},
+		{&http.Request{Host: "z.abc.com", RequestURI: "/foo/bar/"}, "http://foo.com:3001"},
+		{&http.Request{Host: "z.abc.com", RequestURI: "/widget"}, "http://foo.com:901"},
 
 		// do not match on host but maybe on path
 		{&http.Request{Host: "def.com", RequestURI: "/"}, "http://foo.com:800"},
 		{&http.Request{Host: "def.com", RequestURI: "/bar"}, "http://foo.com:800"},
 		{&http.Request{Host: "def.com", RequestURI: "/foo"}, "http://foo.com:900"},
+		{&http.Request{Host: "def.com", RequestURI: "/widget"}, "http://foo.com:901"},
 
 		// strip default port
 		{&http.Request{Host: "abc.com:80", RequestURI: "/"}, "http://foo.com:1000"},


### PR DESCRIPTION
Hi, I've added some code to support a fix for #163. - Pre warning this is my first bit of golang.

I updated the lookup() method in the Table class, that:
1. If no host defined, searches just paths (existing functionality)
2. If a host is defined then does a direct match (existing functionality)
3. If neither, then does a glob search against hosts, then does path matching for each host

I wasn't sure the best way to implement it, but this seems to work

Considering it won't affect existing functionality, I didn't add any additional configuration options, and 'go test' passed.

Also since it's my first attempt at go, I'm not sure whether it is the 'best (go) way of doing' things, or that my function and variable names are right.
