### PR TITLE
allowing route to match host running at any port aimed url

### DIFF
--- a/route/table.go
+++ b/route/table.go
@@ -229,13 +229,11 @@ func (t Table) route(host, path string) *Route {
 // and removes the default port if present.
 func normalizeHost(req *http.Request) string {
 	host := strings.ToLower(req.Host)
-	if req.TLS == nil && strings.HasSuffix(host, ":80") {
-		return host[:len(host)-3]
+	port_index := strings.Index(host, ":")
+	if port_index < 0 {
+		return host
 	}
-	if req.TLS != nil && strings.HasSuffix(host, ":443") {
-		return host[:len(host)-4]
-	}
-	return host
+	return host[0:port_index]
 }
 
 // Lookup finds a target url based on the current matcher and picker


### PR DESCRIPTION
Signed-off-by: AbhishekKr <abhikumar163@gmail.com>

Hey, as per our conversation today
https://twitter.com/magiconair/status/800626305490259968

I've made few changes to Fabio code to support request hostname provided with any port, not just `80|443`.
This works for my use-case without me to provide `Host:` header in `urlprefix-host/` scenario.