### PR TITLE
added log export to graylog with gelf writer

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -60,4 +60,11 @@ var defaultConfig = &Config{
 			APIApp: "fabio",
 		},
 	},
+	LogServer: LogServer{
+		Enabled: false,
+		Protocol: "gelf",
+		Transport: "udp",
+		Port:      "12201",
+		Address:   "127.0.0.1",
+	},
 }

--- a/config/load.go
+++ b/config/load.go
@@ -164,6 +164,11 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 	f.StringVar(&cfg.UI.Addr, "ui.addr", defaultConfig.UI.Addr, "address the UI/API is listening on")
 	f.StringVar(&cfg.UI.Color, "ui.color", defaultConfig.UI.Color, "background color of the UI")
 	f.StringVar(&cfg.UI.Title, "ui.title", defaultConfig.UI.Title, "optional title for the UI")
+	f.BoolVar(&cfg.LogServer.Enabled, "logserver.enabled", defaultConfig.LogServer.Enabled, "enable external logging")
+	f.StringVar(&cfg.LogServer.Protocol, "logserver.protocol", defaultConfig.LogServer.Protocol, "Log format")
+	f.StringVar(&cfg.LogServer.Transport, "logserver.transport", defaultConfig.LogServer.Transport, "udp or tcp transport")
+	f.StringVar(&cfg.LogServer.Port, "logserver.port", defaultConfig.LogServer.Port, "Log Receiver Port")
+	f.StringVar(&cfg.LogServer.Address, "logserver.address", defaultConfig.LogServer.Address, "Hostaddress of the logserver")
 
 	var awsApiGWCertCN string
 	f.StringVar(&awsApiGWCertCN, "aws.apigw.cert.cn", "", "deprecated. use caupgcn=<CN> for cert source")

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -303,6 +303,13 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
+			args: []string{"-Logserver.address", "foobar"},
+			cfg: func(cfg *Config) *Config {
+				cfg.Logserver.address = "foobar"
+				return cfg
+			},
+		},
+		{
 			args: []string{"-proxy.log.routes", "foobar"},
 			cfg: func(cfg *Config) *Config {
 				cfg.Proxy.LogRoutes = "foobar"

--- a/fabio.properties
+++ b/fabio.properties
@@ -733,6 +733,22 @@
 #
 # runtime.gomaxprocs = -1
 
+# Logserver Config sends log to external Server
+#
+# Enable exernal Logserver
+logserver.enabled = true
+#
+# Graylog is implemented using gelf protocol
+# logserver.protocol = gelf
+#
+# Logserver Transport tcp or udp
+# logserver.transport udp
+#
+# Logserver address
+# logserver.address = 127.0.0.1
+#
+# Port of the logserver
+# logserver.port = 12201
 
 # ui.addr configures the address the UI is listening on
 #

--- a/main.go
+++ b/main.go
@@ -12,7 +12,8 @@ import (
 	"runtime/debug"
 	"strings"
 	"time"
-
+	"io"
+	"github.com/Graylog2/go-gelf/gelf"
 	"github.com/eBay/fabio/admin"
 	"github.com/eBay/fabio/config"
 	"github.com/eBay/fabio/exit"
@@ -61,6 +62,7 @@ func main() {
 	// init metrics early since that create the global metric registries
 	// that are used by other parts of the code.
 	initMetrics(cfg)
+	logExternal(cfg)
 
 	initRuntime(cfg)
 	initBackend(cfg)
@@ -273,4 +275,19 @@ func toJSON(v interface{}) string {
 		panic("json: " + err.Error())
 	}
 	return string(data)
+}
+
+func logExternal(cfg *config.Config) {
+   if cfg.LogServer.Enabled {
+     if cfg.LogServer.Protocol == "gelf" {
+     	graylogAddr := cfg.LogServer.Address + ":" + cfg.LogServer.Port
+        gelfWriter, err := gelf.NewWriter(graylogAddr)
+        if err != nil {
+            log.Fatalf("gelf.NewWriter: %s", err)
+        }
+        // log to both stderr and graylog2
+        log.SetOutput(io.MultiWriter(os.Stderr, gelfWriter))
+        log.Printf("logging to stderr & graylog2@'%s'", graylogAddr)
+     }
+  }
 }


### PR DESCRIPTION
Hi Frank, 
i wrote a log exporter for Graylog2 in Gelf format. 

You can test it using this graylog docker-compose https://github.com/raben2/graylog-docker-cluster

Best Regards Georg 