### PR TITLE
Add https upstream support

### DIFF
--- a/registry/consul/service.go
+++ b/registry/consul/service.go
@@ -116,6 +116,8 @@ func serviceConfig(client *api.Client, name string, passing map[string]bool, tag
 				dst := "http://" + addr + "/"
 				if strings.Contains(opts, "proto=tcp") {
 					dst = "tcp://" + addr
+				} else if strings.Contains(opts, "proto=https") {
+					dst = "https://" + addr
 				}
 				tags := strings.Join(svctags, ",")
 

--- a/route/route.go
+++ b/route/route.go
@@ -70,6 +70,7 @@ func (r *Route) addTarget(service string, targetURL *url.URL, fixedWeight float6
 	}
 	if r.Opts != nil {
 		t.StripPath = r.Opts["strip"]
+		t.TLSSkipVerify = r.Opts["tlsskipverify"] == "true"
 	}
 
 	r.Targets = append(r.Targets, t)

--- a/route/target.go
+++ b/route/target.go
@@ -17,6 +17,10 @@ type Target struct {
 	// request path
 	StripPath string
 
+	// TLSSkipVerify disables certificate validation for upstream
+	// TLS connections.
+	TLSSkipVerify bool
+
 	// URL is the endpoint the service instance listens on
 	URL *url.URL
 


### PR DESCRIPTION
This seems to work for me. I generally have a internal root CA that is trusted via standard system certs. The `skipverify` option could be used to deal with self-signed certs, but would obviously skip verification.

I was also thinking of maybe having another certificate store for CAs that could then be selected via a tag option. If that seems like a good idea I can make another PR or amend this one.

Ref: #181 